### PR TITLE
Added bool /object_placed publisher for successful place action (Is…

### DIFF
--- a/code/arlab_manipulation/arlab_manipulation/orchestrator.py
+++ b/code/arlab_manipulation/arlab_manipulation/orchestrator.py
@@ -123,7 +123,7 @@ class orchestrator(Node):
         self.action_result = None
         self.err = ManipulationResponse.UNDEFINED
         self.msg = ""
-        
+
     def octomap_callback(self, msg: PlanningScene):
         """Callback to receive the octomap from the MoveIt planning scene.
 

--- a/code/arlab_manipulation/arlab_manipulation/orchestrator.py
+++ b/code/arlab_manipulation/arlab_manipulation/orchestrator.py
@@ -28,7 +28,7 @@ from rclpy.action.client import ActionClient
 from rclpy.action.server import ActionServer, GoalResponse
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
-from std_msgs.msg import Float64, String
+from std_msgs.msg import Float64, String, Bool
 
 from .utils.octomap_utils import find_placing_area
 from .utils.transform_utils import (
@@ -104,6 +104,9 @@ class orchestrator(Node):
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
 
+        #publisher for object placed
+        self.obj_placed_pub = self.create_publisher(Bool, "/object_placed", 10)
+
         # Default state initialization
         self.entity_id = None
         self.command_type = "home"
@@ -120,7 +123,7 @@ class orchestrator(Node):
         self.action_result = None
         self.err = ManipulationResponse.UNDEFINED
         self.msg = ""
-
+        
     def octomap_callback(self, msg: PlanningScene):
         """Callback to receive the octomap from the MoveIt planning scene.
 
@@ -194,6 +197,13 @@ class orchestrator(Node):
         # Block until the async chain completes (set via finish_action)
         self.action_done_event.wait()
         self.action_done_event.clear()
+
+        # Give feedback if object was correctly placed
+        if self.command_type == "place":
+            placed = Bool()
+            placed.data = (self.err == ManipulationResponse.SUCCESS)   # ← Erfolg-Wert bestätigen
+            self.obj_placed_pub.publish(placed)
+            self.get_logger().info(f'Publishing {placed.data} on /object_placed')  # DEBUG
 
         if not goal_handle.is_active:
             return

--- a/code/arlab_manipulation/arlab_manipulation/orchestrator.py
+++ b/code/arlab_manipulation/arlab_manipulation/orchestrator.py
@@ -104,7 +104,7 @@ class orchestrator(Node):
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
 
-        #publisher for object placed
+        # publisher for object placed
         self.obj_placed_pub = self.create_publisher(Bool, "/object_placed", 10)
 
         # Default state initialization
@@ -201,9 +201,9 @@ class orchestrator(Node):
         # Give feedback if object was correctly placed
         if self.command_type == "place":
             placed = Bool()
-            placed.data = (self.err == ManipulationResponse.SUCCESS)   # ← Erfolg-Wert bestätigen
+            placed.data = self.err == ManipulationResponse.SUCCESS  # ← Erfolg-Wert bestätigen
             self.obj_placed_pub.publish(placed)
-            self.get_logger().info(f'Publishing {placed.data} on /object_placed')  # DEBUG
+            self.get_logger().info(f"Publishing {placed.data} on /object_placed")  # DEBUG
 
         if not goal_handle.is_active:
             return


### PR DESCRIPTION
Issue 37 Implement a Broadcaster for successful place action.

New publisher was manually verified by sending the place goal via the command line:

ros2 action send_goal /manipulation/action arlab_common_interfaces/action/ManipulationAction \ "{command: {command_type: 'place', target_entity_id: 1, target_pose: {position: {x: 0.4, y: 0.0, z: 0.3}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}}"

meanwhile

ros2 topic echo /object_placed 

was open in another terminal, which confirmed the publisher was working.