### PR TITLE
Add Node to offer manual (semantic) entity creation on map in rviz. See Issue #218

### DIFF
--- a/code/arlab_knowledge/arlab_knowledge/db/entities/entity.py
+++ b/code/arlab_knowledge/arlab_knowledge/db/entities/entity.py
@@ -172,7 +172,7 @@ class Entity(Base):
             base=self.pose.pose,
             frame_id=self.pose_reference_frame,
             color=(0.5, 0.5, 0.5, 0.5),
-            size_modifier=0.05,
+            size_modifier=0.5,
         )
 
     def get_point_cloud_marker(self) -> Optional[Marker]:
@@ -214,7 +214,7 @@ class Entity(Base):
                 pose=self.pose.pose,
                 offset=Vector3(x=0.0, y=0.0, z=0.05),
                 color=(1.0, 1.0, 1.0, 0.9),
-                size_modifier=0.05,
+                size_modifier=0.5,
             )
         ]
 

--- a/code/arlab_movement/arlab_movement/entity_placer.py
+++ b/code/arlab_movement/arlab_movement/entity_placer.py
@@ -1,5 +1,5 @@
 """Interactive entity placer node
-Node for manually placing entities (POIs) for semantic annotation of map / env, using rviz for pose selection on map and params for entity args.
+Node for manually placing entities (POIs) for semantic annotation of map / env, using rviz for pose selection on map and extension of AddEntity.srv for metadata.
 
 Maintainers:
 Luca Kahlenberg <luca.kahlenberg@uni-a.de>

--- a/code/arlab_movement/arlab_movement/entity_placer.py
+++ b/code/arlab_movement/arlab_movement/entity_placer.py
@@ -14,8 +14,16 @@ from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from tf2_geometry_msgs.tf2_geometry_msgs import do_transform_pose_stamped
 
 class EntityPlacer(Node):
-    """
-    TODO doc
+    """Node that stages rviz pose clicks and offers a service to add a new entity with staged pose to knowledge base
+
+    We need the possibility to add entities manually to the knowledge base, to enable semantic annotation of map.
+    (kitchen, laundry area) This node is the fallback if automatic annotation via CV fails.
+
+    Workflow:
+    - Set topic of 2D Goal Pose in rviz to /arlab/entity_pose using Panel Tool Properties
+    - Click on displayed /map in rviz to select pose
+    - Call /arlab/entity_placer/place service to add entity (pose, stamp, reference_frame are already set)
+    - Display entities in rviz using topic /arlab/knowledge/visualization
     """
     def __init__(self):
         super().__init__(type(self).__name__)
@@ -72,7 +80,7 @@ class EntityPlacer(Node):
 
     def _pose_callback(self, msg:PoseStamped):
         """
-        TODO doc
+        Callback for /arlab/entity_pose topic, transforms pose to target_frame and stages pose for later use.
         """
         # save pose
         pose = self._to_target_frame(msg)
@@ -85,7 +93,8 @@ class EntityPlacer(Node):
 
     async def _place_callback(self, request:AddEntity.Request, response:AddEntity.Response) -> AddEntity.Response:
         """
-        TODO doc
+        Callback for /arlab/entity_placer/place service, extends AddEntity service by using staged pose, reference_frame and stamp already set by staged pose.
+        Calls AddEntity service to add entity to knowledge base and returns result.
         """
         if self._pending_pose is None:
             response.result.result_type = Result.ERROR_INVALID_INPUT

--- a/code/arlab_movement/arlab_movement/entity_placer.py
+++ b/code/arlab_movement/arlab_movement/entity_placer.py
@@ -5,6 +5,7 @@ using rviz for pose selection on map and extension of AddEntity.srv for metadata
 Maintainers:
 Luca Kahlenberg <luca.kahlenberg@uni-a.de>
 """
+
 import rclpy
 from arlab_knowledge_interfaces.msg import Result
 from arlab_knowledge_interfaces.srv import AddEntity
@@ -12,6 +13,7 @@ from geometry_msgs.msg import PoseStamped
 from rclpy.node import Node
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from tf2_geometry_msgs.tf2_geometry_msgs import do_transform_pose_stamped
+
 
 class EntityPlacer(Node):
     """Node that stages rviz pose clicks and offers a service to add a new entity with staged pose to knowledge base
@@ -25,6 +27,7 @@ class EntityPlacer(Node):
     - Call /arlab/entity_placer/place service to add entity (pose, stamp, reference_frame are already set)
     - Display entities in rviz using topic /arlab/knowledge/visualization
     """
+
     def __init__(self):
         super().__init__(type(self).__name__)
 
@@ -41,7 +44,7 @@ class EntityPlacer(Node):
         self.target_frame = self.get_parameter("target_frame").get_parameter_value().string_value
         self.pose_topic = self.get_parameter("pose_topic").get_parameter_value().string_value
         self.add_entity_service = self.get_parameter("add_entity_service").get_parameter_value().string_value
-        self._place_service_name  = self.get_parameter("place_service").get_parameter_value().string_value
+        self._place_service_name = self.get_parameter("place_service").get_parameter_value().string_value
         self._pending_pose = None
         self.service_timeout = 5.0
 
@@ -77,8 +80,7 @@ class EntityPlacer(Node):
             f"Entities are added in frame '{self.target_frame}')."
         )
 
-
-    def _pose_callback(self, msg:PoseStamped):
+    def _pose_callback(self, msg: PoseStamped):
         """
         Callback for /arlab/entity_pose topic, transforms pose to target_frame and stages pose for later use.
         """
@@ -90,8 +92,7 @@ class EntityPlacer(Node):
         self._pending_pose = pose
         self.get_logger().info(f"Received and staged new pose: {pose}")
 
-
-    async def _place_callback(self, request:AddEntity.Request, response:AddEntity.Response) -> AddEntity.Response:
+    async def _place_callback(self, request: AddEntity.Request, response: AddEntity.Response) -> AddEntity.Response:
         """
         Callback for /arlab/entity_placer/place service.
         Extends AddEntity service by using staged pose, reference_frame and stamp already set by staged pose.
@@ -134,8 +135,7 @@ class EntityPlacer(Node):
 
         return response
 
-
-    def _to_target_frame(self, msg:PoseStamped) -> PoseStamped:
+    def _to_target_frame(self, msg: PoseStamped) -> PoseStamped:
         """
         transforms any PoseStamped to target frame (map)
         """
@@ -155,7 +155,7 @@ class EntityPlacer(Node):
 
 
 def main(args=None):
-    """ Entry point for node"""
+    """Entry point for node"""
     rclpy.init(args=args)
     node = EntityPlacer()
     rclpy.spin(node)

--- a/code/arlab_movement/arlab_movement/entity_placer.py
+++ b/code/arlab_movement/arlab_movement/entity_placer.py
@@ -24,17 +24,16 @@ class EntityPlacer(Node):
 
         self.declare_parameter("pose_topic", "/arlab/entity_pose")
         self.declare_parameter("target_frame", "map")
-        self.declare_parameter("entity_type_id", 0)
-        self.declare_parameter("description", "new_poi")
 
         self.declare_parameter("add_entity_service", "/arlab/knowledge/add_entity")
-        self.declare_parameter("commit_service", "/arlab/entity_placer/commit")
+        self.declare_parameter("place_service", "/arlab/entity_placer/place")
 
         # set self vars
 
         self.target_frame = self.get_parameter("target_frame").get_parameter_value().string_value
         self.pose_topic = self.get_parameter("pose_topic").get_parameter_value().string_value
         self.add_entity_service = self.get_parameter("add_entity_service").get_parameter_value().string_value
+        self._place_service_name  = self.get_parameter("place_service").get_parameter_value().string_value
         self._pending_pose = None
         self.service_timeout = 5.0
 
@@ -55,12 +54,10 @@ class EntityPlacer(Node):
 
         # create services
 
-        self._commit_service_name = self.get_parameter("commit_service").get_parameter_value().string_value
-
         self.create_service(
-            Trigger,
-            self._commit_service_name,
-            self._commit_callback,
+            AddEntity,
+            self._place_service_name,
+            self._place_callback,
             callback_group=self.trigger_group,
         )
 
@@ -68,8 +65,8 @@ class EntityPlacer(Node):
 
         self.get_logger().info(
             f"Staging poses from '{self.pose_topic}'.\n"
-            f"Commit via '{self._commit_service_name}'.\n"
-            f"TODO implement tf: (Entities should be added in frame '{self.target_frame}')."
+            f"Place Entity / Add to DB via '{self._place_service_name}'.\n"
+            f"Entities are added in frame '{self.target_frame}')."
         )
 
 
@@ -78,7 +75,7 @@ class EntityPlacer(Node):
         TODO doc
         """
         # save pose
-        pose = self._to_target_fram(msg)
+        pose = self._to_target_frame(msg)
         if pose is None:
             return
 
@@ -86,49 +83,49 @@ class EntityPlacer(Node):
         self.get_logger().info(f"Received and staged new pose: {pose}")
 
 
-    async def _commit_callback(self, request:Trigger.Request, response:Trigger.Response) -> Trigger.Response:
+    async def _place_callback(self, request:AddEntity.Request, response:AddEntity.Response) -> AddEntity.Response:
         """
         TODO doc
         """
         if self._pending_pose is None:
-            response.success = False
-            response.message = "No pose staged"
+            response.result.result_type = Result.ERROR_INVALID_INPUT
+            response.result.error = "No pose staged"
             return response
 
-        # create entity from pose
+        pose = self._pending_pose
 
-        entity = Entity()
-        entity.entity_type = EntityType(id=self.get_parameter("entity_type_id").get_parameter_value().integer_value)
-        entity.description = self.get_parameter("description").get_parameter_value().string_value
-        entity.pose = self._pending_pose.pose
-        entity.pose_reference_frame = self._pending_pose.header.frame_id
-        entity.stamp = self._pending_pose.header.stamp
+        request.data.pose = pose.pose
+        request.data.pose_reference_frame = pose.header.frame_id
+        request.data.stamp = pose.header.stamp
 
         # call add_entity service
 
         client = self.create_client(AddEntity, self.add_entity_service)
 
         if not client.wait_for_service(timeout_sec=self.service_timeout):
-            response.success = False
-            response.message = "service not available"
+            response.result.result_type = Result.ERROR_BUSY
+            response.result.error = "service not available"
             return response
 
-        req = AddEntity.Request()
-        req.data = entity
-        res = await client.call_async(req)
-
-        if res.result.result_type != Result.SUCCESS:
-            response.success = False
-            response.message = f"Failed to add entity: {res.result.error}"
+        try:
+            res = await client.call_async(request)
+        except Exception as e:
+            response.result.result_type = Result.ERROR_DBAPI
+            response.result.error = f"AddEntity sercive call failed: {e}"
             return response
 
-        response.success = True
-        response.message = f"Entity added successfully with id: {res.entityid}"
-        self.get_logger().info(response.message)
+        response.entityid = res.entityid
+        response.result = res.result
+
+        if res.result.result_type == Result.SUCCESS:
+            self.get_logger().info(f"Entity added successfully with id: {res.entityid}")
+        else:
+            self.get_logger().error(f"Failed to add entity: {res.result.error}")
+
         return response
 
 
-    def _to_target_fram(self, msg:PoseStamped) -> PoseStamped:
+    def _to_target_frame(self, msg:PoseStamped) -> PoseStamped:
         """
         transforms any PoseStamped to target frame (map)
         """

--- a/code/arlab_movement/arlab_movement/entity_placer.py
+++ b/code/arlab_movement/arlab_movement/entity_placer.py
@@ -1,0 +1,138 @@
+"""Interactive entity placer node
+Node for manually placing entities (POIs) for semantic annotation of map / env, using rviz for pose selection on map and params for entity args.
+
+Maintainers:
+Luca Kahlenberg <luca.kahlenberg@uni-a.de>
+"""
+import rclpy
+from arlab_knowledge_interfaces.msg import Entity, EntityType, Result
+from arlab_knowledge_interfaces.srv import AddEntity
+from geometry_msgs.msg import PoseStamped
+from std_srvs.srv import Trigger
+from rclpy.node import Node
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+
+class EntityPlacer(Node):
+    """
+    TODO doc
+    """
+    def __init__(self):
+        super().__init__(type(self).__name__)
+
+        # declare parameters
+
+        self.declare_parameter("pose_topic", "/arlab/entity_pose")
+        self.declare_parameter("target_frame", "map")
+        self.declare_parameter("entity_type_id", 0)
+        self.declare_parameter("description", "new_poi")
+
+        self.declare_parameter("add_entity_service", "/arlab/knowledge/add_entity")
+        self.declare_parameter("commit_service", "/arlab/entity_placer/commit")
+
+        # set self vars
+
+        self.target_frame = self.get_parameter("target_frame").get_parameter_value().string_value
+        self.pose_topic = self.get_parameter("pose_topic").get_parameter_value().string_value
+        self.add_entity_service = self.get_parameter("add_entity_service").get_parameter_value().string_value
+        self._pending_pose = None
+        self.service_timeout = 5.0
+
+        # callback groups
+
+        self.subscription_group = MutuallyExclusiveCallbackGroup()
+        self.trigger_group = MutuallyExclusiveCallbackGroup()
+
+        # sub to pose topic
+
+        self.create_subscription(
+            PoseStamped,
+            self.pose_topic,
+            self._pose_callback,
+            qos_profile=10,
+            callback_group=self.subscription_group,
+        )
+
+        # create services
+
+        self._commit_service_name = self.get_parameter("commit_service").get_parameter_value().string_value
+
+        self.create_service(
+            Trigger,
+            self._commit_service_name,
+            self._commit_callback,
+            callback_group=self.trigger_group,
+        )
+
+        # log info
+
+        self.get_logger().info(
+            f"Staging poses from '{self.pose_topic}'.\n"
+            f"Commit via '{self._commit_service_name}'.\n"
+            f"TODO implement tf: (Entities should be added in frame '{self.target_frame}')."
+        )
+
+
+    def _pose_callback(self, msg:PoseStamped):
+        """
+        TODO doc
+        """
+        # save pose
+        pose = msg.pose
+        if pose is None:
+            return
+
+        self._pending_pose = pose
+        self.get_logger().info(f"Received and staged new pose: {pose}")
+
+
+    def _commit_callback(self, request:Trigger.Request, response:Trigger.Response) -> Trigger.Response:
+        """
+        TODO doc
+        """
+        if self._pending_pose is None:
+            response.success = False
+            response.message = "No pose staged"
+            return response
+
+        # create entity from pose
+
+        entity = Entity()
+        entity.entity_type = EntityType(id=self.get_parameter("entity_type_id").get_parameter_value().integer_value)
+        entity.description = self.get_parameter("description").get_parameter_value().string_value
+        entity.pose = self._pending_pose
+
+        # call add_entity service
+
+        client = self.create_client(AddEntity, self.add_entity_service)
+
+        if not client.wait_for_service(timeout_sec=self.service_timeout):
+            response.success = False
+            response.message = "service not available"
+            return response
+
+        req = AddEntity.Request()
+        req.data = entity
+        res = client.call_async(req)
+
+        if res.result.result_type != Result.SUCCESS:
+            response.success = False
+            response.message = f"Failed to add entity: {res.result.error}"
+            return response
+
+        response.success = True
+        response.message = f"Entity added successfully with id: {res.entityid}"
+        self.get_logger().info(response.message)
+        return response
+
+
+def main(args=None):
+    """ Entry point for node"""
+    rclpy.init(args=args)
+    node = EntityPlacer()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/arlab_movement/arlab_movement/entity_placer.py
+++ b/code/arlab_movement/arlab_movement/entity_placer.py
@@ -11,6 +11,7 @@ from geometry_msgs.msg import PoseStamped
 from std_srvs.srv import Trigger
 from rclpy.node import Node
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from tf2_geometry_msgs.tf2_geometry_msgs import do_transform_pose_stamped
 
 class EntityPlacer(Node):
     """
@@ -77,7 +78,7 @@ class EntityPlacer(Node):
         TODO doc
         """
         # save pose
-        pose = msg.pose
+        pose = self._to_target_fram(msg)
         if pose is None:
             return
 
@@ -85,7 +86,7 @@ class EntityPlacer(Node):
         self.get_logger().info(f"Received and staged new pose: {pose}")
 
 
-    def _commit_callback(self, request:Trigger.Request, response:Trigger.Response) -> Trigger.Response:
+    async def _commit_callback(self, request:Trigger.Request, response:Trigger.Response) -> Trigger.Response:
         """
         TODO doc
         """
@@ -99,7 +100,9 @@ class EntityPlacer(Node):
         entity = Entity()
         entity.entity_type = EntityType(id=self.get_parameter("entity_type_id").get_parameter_value().integer_value)
         entity.description = self.get_parameter("description").get_parameter_value().string_value
-        entity.pose = self._pending_pose
+        entity.pose = self._pending_pose.pose
+        entity.pose_reference_frame = self._pending_pose.header.frame_id
+        entity.stamp = self._pending_pose.header.stamp
 
         # call add_entity service
 
@@ -112,7 +115,7 @@ class EntityPlacer(Node):
 
         req = AddEntity.Request()
         req.data = entity
-        res = client.call_async(req)
+        res = await client.call_async(req)
 
         if res.result.result_type != Result.SUCCESS:
             response.success = False
@@ -123,6 +126,25 @@ class EntityPlacer(Node):
         response.message = f"Entity added successfully with id: {res.entityid}"
         self.get_logger().info(response.message)
         return response
+
+
+    def _to_target_fram(self, msg:PoseStamped) -> PoseStamped:
+        """
+        transforms any PoseStamped to target frame (map)
+        """
+        if msg.header.frame_id == self.target_frame:
+            return msg
+        try:
+            transform = self.tf_buffer.lookup_transform(
+                self.target_frame,
+                msg.header.frame_id,
+                rclpy.time.Time(),
+                timeout=rclpy.duration.Duration(seconds=self.service_timeout),
+            )
+            return do_transform_pose_stamped(msg, transform)
+        except Exception as e:
+            self.get_logger().error(f"Failed to transform pose to target frame: {e}")
+            return None
 
 
 def main(args=None):

--- a/code/arlab_movement/arlab_movement/entity_placer.py
+++ b/code/arlab_movement/arlab_movement/entity_placer.py
@@ -1,14 +1,14 @@
 """Interactive entity placer node
-Node for manually placing entities (POIs) for semantic annotation of map / env, using rviz for pose selection on map and extension of AddEntity.srv for metadata.
+Node for manually placing entities (POIs) for semantic annotation of map / env,
+using rviz for pose selection on map and extension of AddEntity.srv for metadata.
 
 Maintainers:
 Luca Kahlenberg <luca.kahlenberg@uni-a.de>
 """
 import rclpy
-from arlab_knowledge_interfaces.msg import Entity, EntityType, Result
+from arlab_knowledge_interfaces.msg import Result
 from arlab_knowledge_interfaces.srv import AddEntity
 from geometry_msgs.msg import PoseStamped
-from std_srvs.srv import Trigger
 from rclpy.node import Node
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from tf2_geometry_msgs.tf2_geometry_msgs import do_transform_pose_stamped
@@ -93,7 +93,8 @@ class EntityPlacer(Node):
 
     async def _place_callback(self, request:AddEntity.Request, response:AddEntity.Response) -> AddEntity.Response:
         """
-        Callback for /arlab/entity_placer/place service, extends AddEntity service by using staged pose, reference_frame and stamp already set by staged pose.
+        Callback for /arlab/entity_placer/place service.
+        Extends AddEntity service by using staged pose, reference_frame and stamp already set by staged pose.
         Calls AddEntity service to add entity to knowledge base and returns result.
         """
         if self._pending_pose is None:

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -49,7 +49,7 @@ class NavigationOrchestrator(Node):
         self.service_group = MutuallyExclusiveCallbackGroup()
         self.action_group = ReentrantCallbackGroup()
 
-        # Initialize parameters set in ../paraparams.yamlms/arlab_navigation_
+        # Initialize parameters set in ../params/arlab_navigation_params.yaml
         self.declare_parameter("map_path", "/workspace/src/arlab/code/arlab_movement/map/my_map")
         self.declare_parameter("use_timestamp", False)
         self.declare_parameter("save_to_database", False)

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -49,7 +49,7 @@ class NavigationOrchestrator(Node):
         self.service_group = MutuallyExclusiveCallbackGroup()
         self.action_group = ReentrantCallbackGroup()
 
-        # Initialize parameters set in ../params/arlab_navigation_params.yaml
+        # Initialize parameters set in ../paraparams.yamlms/arlab_navigation_
         self.declare_parameter("map_path", "/workspace/src/arlab/code/arlab_movement/map/my_map")
         self.declare_parameter("use_timestamp", False)
         self.declare_parameter("save_to_database", False)

--- a/code/arlab_movement/launch/custom_spawn_turtlebot3.launch.py
+++ b/code/arlab_movement/launch/custom_spawn_turtlebot3.launch.py
@@ -58,7 +58,6 @@ def generate_launch_description():
 
     bridge_params = "/workspace/install/arlab_movement/share/arlab_movement/params/bridge_params.yaml"
 
-
     start_gazebo_ros_bridge_cmd = Node(
         package="ros_gz_bridge",
         executable="parameter_bridge",

--- a/code/arlab_movement/launch/custom_spawn_turtlebot3.launch.py
+++ b/code/arlab_movement/launch/custom_spawn_turtlebot3.launch.py
@@ -56,7 +56,8 @@ def generate_launch_description():
         output="screen",
     )
 
-    bridge_params = "/workspace/build/arlab_movement/params/bridge_params.yaml"
+    bridge_params = "/workspace/install/arlab_movement/share/arlab_movement/params/bridge_params.yaml"
+
 
     start_gazebo_ros_bridge_cmd = Node(
         package="ros_gz_bridge",

--- a/code/arlab_movement/launch/nav2.launch.py
+++ b/code/arlab_movement/launch/nav2.launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time")
     autostart = LaunchConfiguration("autostart")
     params_file = LaunchConfiguration("params_file")
-    use_composition = "use_composition"
+    use_composition = LaunchConfiguration("use_composition")
     container_name = LaunchConfiguration("container_name")
     container_name_full = (namespace, "/", container_name)
     use_respawn = LaunchConfiguration("use_respawn")
@@ -80,7 +80,7 @@ def generate_launch_description():
 
     declare_params_file_cmd = DeclareLaunchArgument(
         "params_file",
-        default_value="/workspace/build/arlab_movement/params/nav2_params.yaml",
+        default_value="/workspace/install/arlab_movement/share/arlab_movement/params/nav2_params.yaml",
         description="Full path to the ROS2 parameters file to use for all launched nodes",
     )
 

--- a/code/arlab_movement/package.xml
+++ b/code/arlab_movement/package.xml
@@ -40,7 +40,6 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>teleop_twist_keyboard</exec_depend>
-  <exec_depend>std_srvs</exec_depend>
 
   <!--dependencie for rosbot_xl-->
   <depend>laser_filters</depend>

--- a/code/arlab_movement/package.xml
+++ b/code/arlab_movement/package.xml
@@ -21,9 +21,9 @@
   <depend>nav2_costmap_2d</depend>
   <depend>nav2_route</depend>
   <depend>nav2_waypoint_follower</depend>
-  <depend>rclpy</depend> 
-  <depend>geometry_msgs</depend> 
-  <depend>tf2_ros</depend> 
+  <depend>rclpy</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <depend>turtlebot3</depend>
   <depend>turtlebot3_navigation2</depend>
@@ -40,6 +40,7 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>teleop_twist_keyboard</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
 
   <!--dependencie for rosbot_xl-->
   <depend>laser_filters</depend>

--- a/code/arlab_movement/params/arlab_navigation_params.yaml
+++ b/code/arlab_movement/params/arlab_navigation_params.yaml
@@ -2,15 +2,15 @@ navigation_orchestrator:
   ros__parameters:
     # Map saving parameters
     map_path: "/workspace/src/arlab/code/arlab_movement/map/my_map"
-    
+
     # Adding timestamps to filename
     use_timestamp: false
-    
+
     amcl_enabled: true
     slam_enabled: true
     nav_enabled: true
 
-    save_to_database: false
+    save_to_database: true
     map_topic: "/map"
     database_service: "/arlab/knowledge/add_map"
     database_timeout: 10.0

--- a/code/arlab_movement/setup.py
+++ b/code/arlab_movement/setup.py
@@ -35,6 +35,7 @@ setup(
             "dummy = arlab_movement.dummy:main",
             "map_save_publisher = arlab_movement.map_save_publisher:main",
             "movement_orchestrator = arlab_movement.movement_orchestrator:main",
+            "entity_placer = arlab_movement.entity_placer:main",
         ],
     },
 )


### PR DESCRIPTION
Node that stages rviz pose clicks and offers a service to add a new entity with staged pose to knowledge base.

We need the possibility to add entities manually to the knowledge base, to enable semantic annotation of map (kitchen, laundry area) This node is the fallback if automatic annotation via CV fails.

Workflow:
- Set topic of 2D Goal Pose in rviz to /arlab/entity_pose using Panel Tool Properties
- Click on displayed /map in rviz to select pose using 2D Goal Pose Tool
- Call /arlab/entity_placer/place service to add entity (pose, stamp, reference_frame are already set)
- Display entities in rviz using topic /arlab/knowledge/visualization

To use this in simulation with turtlebot, start in different terminals:
```
ros2 run rviz2 rviz2
ros2 launch husarion_gz_worlds gz_sim.launch.py 
ros2 launch turtlebot3_gazebo robot_state_publisher.launch.py
ros2 launch arlab_movement custom_spawn_turtlebot3.launch.py x_pose:=5.0
ros2 run arlab_movement movement_orchestrator --ros-args --params-file <path to param file>
ros2 launch arlab_knowledge knowledge_launch.py
ros2 run arlab_movement entity_placer
```

For later convenience. maybe add a small script for service call in another PR.