### PR TITLE
Use knowledge interface result types in AddMap service of movement orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,7 @@ cython_debug/
 
 # Ruff
 .ruff_cache
+
+# map testing
+*.pgm
+my_map.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,5 @@ cython_debug/
 # map testing
 *.pgm
 my_map.yaml
+code/arlab_movement/map/my_map.pgm
+code/arlab_movement/map/my_map.yaml

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -26,6 +26,7 @@ from rclpy.action.server import ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
 from rclpy.node import Node
 from std_msgs.msg import Bool
+from arlab_knowledge_interfaces.msg import Result
 
 
 class NavErr:
@@ -477,7 +478,8 @@ class NavigationOrchestrator(Node):
             return NavErr.DB_SAVE_FAILED, f"Database call failed: {e}"
 
         for ok_field in ("success", "result"):
-            if hasattr(resp, ok_field) and bool(getattr(resp, ok_field)):
+            if hasattr(resp, ok_field) and resp.result.result_type == Result.SUCCESS:
+                self.get_logger().info("Map added with id: " + str(resp.mapid))
                 return NavErr.OK, "Map saved to database"
 
         for msg_field in ("message", "error_message", "error"):


### PR DESCRIPTION
Before, the AddMap service in the movement orchestrator did not use the result_type from `arlab_knowledge_interfaces/Result.msg`.
Now the orchestrator uses knowledge interfaces and logs the id of added maps to the terminal.