### PR TITLE
[#221] add task-related entities (dishwasher, washer, laundry basket, trash bin)

### DIFF
--- a/code/arlab_knowledge/arlab_knowledge/db/entities/__init__.py
+++ b/code/arlab_knowledge/arlab_knowledge/db/entities/__init__.py
@@ -58,6 +58,14 @@ def entity_msg_type_to_class(msg_type: msg.EntityType) -> type | None:
         return furniture.Shelf
     if msg_type.id == msg.EntityType.TABLE:
         return furniture.Table
+    if msg_type.id == msg.EntityType.DISHWASHER:
+        return furniture.Dishwasher
+    if msg_type.id == msg.EntityType.WASHER:
+        return furniture.Washer
+    if msg_type.id == msg.EntityType.LAUNDRY_BASKET:
+        return furniture.LaundryBasket
+    if msg_type.id == msg.EntityType.TRASH_BIN:
+        return furniture.TrashBin
     else:
         return None
 
@@ -91,4 +99,12 @@ def entity_extract_type_msg(e: entity.Entity) -> msg.EntityType:
         m.id = msg.EntityType.SHELF
     if isinstance(e, furniture.Table):
         m.id = msg.EntityType.TABLE
+    if isinstance(e, furniture.Dishwasher):
+        m.id = msg.EntityType.DISHWASHER
+    if isinstance(e, furniture.Washer):
+        m.id = msg.EntityType.WASHER
+    if isinstance(e, furniture.LaundryBasket):
+        m.id = msg.EntityType.LAUNDRY_BASKET
+    if isinstance(e, furniture.TrashBin):
+        m.id = msg.EntityType.TRASH_BIN
     return m

--- a/code/arlab_knowledge/arlab_knowledge/db/entities/furniture.py
+++ b/code/arlab_knowledge/arlab_knowledge/db/entities/furniture.py
@@ -11,6 +11,10 @@ Furniture types:
 - Door: A door
 - Shelf: A shelf that is part of a cupboard
 - Table: A table
+- Dishwaser: A dishwasher
+- Washer: A washing machine
+- TrashBin: A trash bin
+- LaundryBasket: A laundry basket
 
 The furniture system uses polymorphic inheritance to handle different furniture
 types while maintaining a unified database schema. Each furniture type has
@@ -404,4 +408,296 @@ class Table(Furniture):
         m = super().to_ros_msg()
         # Populate table-specific field in the nested message structure
         m.furniture.table.height = self.height
+        return m
+
+
+class Dishwasher(Furniture):
+    """A dishwasher.
+
+    This subclass represents a dishwasher furniture object. Dishwashers have
+    specific dimensions (width, height) and an open/closed state.
+    """
+
+    __tablename__ = "entity_furniture_dishwasher"
+    id: Mapped[int] = mapped_column(
+        ForeignKey("entity_furniture.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    """Foreign key to the parent furniture record.
+
+    This column serves as the primary key for the dishwasher table while also
+    linking to the parent Furniture record. When the parent is deleted,
+    this dishwasher record is also deleted (CASCADE).
+    """
+
+    height: Mapped[float]
+    """Height of the dishwasher in meters."""
+
+    width: Mapped[float]
+    """Width of the dishwasher in meters."""
+
+    open: Mapped[str]
+    """Open state of the dishwasher.
+
+    Stores the open/closed state as a string (e.g., "open", "closed").
+    """
+
+    __mapper_args__ = {
+        "polymorphic_identity": "entity_furniture_dishwasher",
+    }
+
+    @classmethod
+    def _extract_kwargs(cls, m: msg.Entity) -> Dict:
+        """Extracts keyword arguments for creating a Dishwasher instance.
+
+        This method calls the parent's _extract_kwargs to get common attributes,
+        then extracts dishwasher-specific attributes from the ROS message.
+
+        Args:
+            m: The ROS Entity message to extract data from
+
+        Returns:
+            A dictionary containing attributes from the parent class plus
+            width, height, and open from the dishwasher-specific message fields
+        """
+        kwargs = super()._extract_kwargs(m)
+        # Extract dishwasher-specific attributes from the nested message structure
+        kwargs["height"] = m.furniture.dishwasher.height
+        kwargs["width"] = m.furniture.dishwasher.width
+        kwargs["open"] = m.furniture.dishwasher.open
+        return kwargs
+
+    def to_ros_msg(self) -> msg.Entity:
+        """Converts this dishwasher instance to a ROS message.
+
+        This method calls the parent's to_ros_msg and populates the dishwasher-specific
+        fields in the nested message structure.
+
+        Returns:
+            A ROS Entity message populated with this instance's data
+        """
+        m = super().to_ros_msg()
+        # Populate dishwasher-specific fields in the nested message structure
+        m.furniture.dishwasher.height = self.height
+        m.furniture.dishwasher.width = self.width
+        m.furniture.dishwasher.open = self.open
+        return m
+
+
+class Washer(Furniture):
+    """A washing machine.
+
+    This subclass represents a washing machine furniture object. Washers have
+    specific dimensions (width, height) and an open/closed state.
+    """
+
+    __tablename__ = "entity_furniture_washer"
+    id: Mapped[int] = mapped_column(
+        ForeignKey("entity_furniture.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    """Foreign key to the parent furniture record.
+
+    This column serves as the primary key for the washer table while also
+    linking to the parent Furniture record. When the parent is deleted,
+    this washer record is also deleted (CASCADE).
+    """
+
+    height: Mapped[float]
+    """Height of the washer in meters."""
+
+    width: Mapped[float]
+    """Width of the washer in meters."""
+
+    open: Mapped[str]
+    """Open state of the washer.
+
+    Stores the open/closed state as a string (e.g., "open", "closed").
+    """
+
+    __mapper_args__ = {
+        "polymorphic_identity": "entity_furniture_washer",
+    }
+
+    @classmethod
+    def _extract_kwargs(cls, m: msg.Entity) -> Dict:
+        """Extracts keyword arguments for creating a Washer instance.
+
+        This method calls the parent's _extract_kwargs to get common attributes,
+        then extracts washer-specific attributes from the ROS message.
+
+        Args:
+            m: The ROS Entity message to extract data from
+
+        Returns:
+            A dictionary containing attributes from the parent class plus
+            width, height, and open from the washer-specific message fields
+        """
+        kwargs = super()._extract_kwargs(m)
+        # Extract washer-specific attributes from the nested message structure
+        kwargs["height"] = m.furniture.washer.height
+        kwargs["width"] = m.furniture.washer.width
+        kwargs["open"] = m.furniture.washer.open
+        return kwargs
+
+    def to_ros_msg(self) -> msg.Entity:
+        """Converts this washer instance to a ROS message.
+
+        This method calls the parent's to_ros_msg and populates the washer-specific
+        fields in the nested message structure.
+
+        Returns:
+            A ROS Entity message populated with this instance's data
+        """
+        m = super().to_ros_msg()
+        # Populate washer-specific fields in the nested message structure
+        m.furniture.washer.height = self.height
+        m.furniture.washer.width = self.width
+        m.furniture.washer.open = self.open
+        return m
+
+
+class LaundryBasket(Furniture):
+    """A laundry basket.
+
+    This subclass represents a laundry basket furniture object. Laundry baskets
+    have specific dimensions (width, height).
+    """
+
+    __tablename__ = "entity_furniture_laundry_basket"
+    id: Mapped[int] = mapped_column(
+        ForeignKey("entity_furniture.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    """Foreign key to the parent furniture record.
+
+    This column serves as the primary key for the laundry basket table while
+    also linking to the parent Furniture record. When the parent is deleted,
+    this laundry basket record is also deleted (CASCADE).
+    """
+
+    height: Mapped[float]
+    """Height of the laundry basket in meters."""
+
+    width: Mapped[float]
+    """Width of the laundry basket in meters."""
+
+    __mapper_args__ = {
+        "polymorphic_identity": "entity_furniture_laundry_basket",
+    }
+
+    @classmethod
+    def _extract_kwargs(cls, m: msg.Entity) -> Dict:
+        """Extracts keyword arguments for creating a LaundryBasket instance.
+
+        This method calls the parent's _extract_kwargs to get common attributes,
+        then extracts laundry basket-specific attributes from the ROS message.
+
+        Args:
+            m: The ROS Entity message to extract data from
+
+        Returns:
+            A dictionary containing attributes from the parent class plus
+            width and height from the laundry basket-specific message fields
+        """
+        kwargs = super()._extract_kwargs(m)
+        # Extract laundry basket-specific attributes from the nested message structure
+        kwargs["height"] = m.furniture.laundry_basket.height
+        kwargs["width"] = m.furniture.laundry_basket.width
+        return kwargs
+
+    def to_ros_msg(self) -> msg.Entity:
+        """Converts this laundry basket instance to a ROS message.
+
+        This method calls the parent's to_ros_msg and populates the laundry basket-specific
+        fields in the nested message structure.
+
+        Returns:
+            A ROS Entity message populated with this instance's data
+        """
+        m = super().to_ros_msg()
+        # Populate laundry basket-specific fields in the nested message structure
+        m.furniture.laundry_basket.height = self.height
+        m.furniture.laundry_basket.width = self.width
+        return m
+
+
+class TrashBin(Furniture):
+    """A trash bin.
+
+    This subclass represents a trash bin furniture object. Trash bins have
+    specific dimensions (width, height), a lid indicator, and an open/closed state.
+    """
+
+    __tablename__ = "entity_furniture_trash_bin"
+    id: Mapped[int] = mapped_column(
+        ForeignKey("entity_furniture.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    """Foreign key to the parent furniture record.
+
+    This column serves as the primary key for the trash bin table while also
+    linking to the parent Furniture record. When the parent is deleted,
+    this trash bin record is also deleted (CASCADE).
+    """
+
+    height: Mapped[float]
+    """Height of the trash bin in meters."""
+
+    width: Mapped[float]
+    """Width of the trash bin in meters."""
+
+    has_lid: Mapped[str]
+    """Whether the trash bin has a lid.
+
+    Stores the lid presence as a string (e.g., "true", "false").
+    """
+
+    open: Mapped[str]
+    """Open state of the trash bin.
+
+    Stores the open/closed state as a string (e.g., "open", "closed").
+    """
+
+    __mapper_args__ = {
+        "polymorphic_identity": "entity_furniture_trash_bin",
+    }
+
+    @classmethod
+    def _extract_kwargs(cls, m: msg.Entity) -> Dict:
+        """Extracts keyword arguments for creating a TrashBin instance.
+
+        This method calls the parent's _extract_kwargs to get common attributes,
+        then extracts trash bin-specific attributes from the ROS message.
+
+        Args:
+            m: The ROS Entity message to extract data from
+
+        Returns:
+            A dictionary containing attributes from the parent class plus
+            width, height, has_lid, and open from the trash bin-specific message fields
+        """
+        kwargs = super()._extract_kwargs(m)
+        # Extract trash bin-specific attributes from the nested message structure
+        kwargs["height"] = m.furniture.trash_bin.height
+        kwargs["width"] = m.furniture.trash_bin.width
+        kwargs["has_lid"] = m.furniture.trash_bin.has_lid
+        kwargs["open"] = m.furniture.trash_bin.open
+        return kwargs
+
+    def to_ros_msg(self) -> msg.Entity:
+        """Converts this trash bin instance to a ROS message.
+
+        This method calls the parent's to_ros_msg and populates the trash bin-specific
+        fields in the nested message structure.
+
+        Returns:
+            A ROS Entity message populated with this instance's data
+        """
+        m = super().to_ros_msg()
+        # Populate trash bin-specific fields in the nested message structure
+        m.furniture.trash_bin.height = self.height
+        m.furniture.trash_bin.width = self.width
+        m.furniture.trash_bin.has_lid = self.has_lid
+        m.furniture.trash_bin.open = self.open
         return m

--- a/code/arlab_knowledge/arlab_knowledge/test_utils.py
+++ b/code/arlab_knowledge/arlab_knowledge/test_utils.py
@@ -20,6 +20,10 @@ from arlab_knowledge.db.entities.furniture import (
     Furniture,
     Shelf,
     Table,
+    Dishwasher,
+    Washer,
+    LaundryBasket,
+    TrashBin,
 )
 from arlab_knowledge.db.entities.human import Human
 from arlab_knowledge.db.entities.pickable import Pickable
@@ -185,6 +189,62 @@ def get_table():
         pose_reference_frame="map",
         stamp=TimeData(stamp),
         height=1.5,
+    )
+
+
+def get_dishwasher():
+    pose = create_pose()
+    stamp = create_stamp()
+    return Dishwasher(
+        description="TestDishwasher",
+        pose=PoseData(pose),
+        pose_reference_frame="map",
+        stamp=TimeData(stamp),
+        width=0.6,
+        height=0.85,
+        open="false",
+    )
+
+
+def get_washer():
+    pose = create_pose()
+    stamp = create_stamp()
+    return Washer(
+        description="TestWasher",
+        pose=PoseData(pose),
+        pose_reference_frame="map",
+        stamp=TimeData(stamp),
+        width=0.6,
+        height=0.85,
+        open="false",
+    )
+
+
+def get_laundry_basket():
+    pose = create_pose()
+    stamp = create_stamp()
+    return LaundryBasket(
+        description="TestLaundryBasket",
+        pose=PoseData(pose),
+        pose_reference_frame="map",
+        stamp=TimeData(stamp),
+        height=0.5,
+        width=0.4,
+    )
+
+
+def get_trash_bin():
+    pose = create_pose()
+    stamp = create_stamp()
+    return TrashBin(
+        description="TestTrashBin",
+        pose=PoseData(pose),
+        pose_reference_frame="map",
+        stamp=TimeData(stamp),
+        height=0.5,
+        width=0.4,
+        has_lid="false",
+        open="true",
     )
 
 

--- a/code/arlab_knowledge/tests/test_database_node.py
+++ b/code/arlab_knowledge/tests/test_database_node.py
@@ -3,6 +3,8 @@
 These tests are not compatible with `pytest`/`colcon test` and need to be manually
 executed via `python3 test_database_node.py`.
 
+Note: The new entities (Dishwasher, Washer, LaundryBasket, TrashBin) are not yet covered by update test.
+
 Maintainers:
     Peter Viechter <peter.viechter@uni-a.de>
     Daniel Gabler <daniel.gabler@uni-a.de>
@@ -53,6 +55,10 @@ class DatabaseServiceTester(Node):
             self.test_add_cupboard,
             self.test_add_shelf,
             self.test_add_table,
+            self.test_add_dishwasher,
+            self.test_add_washer,
+            self.test_add_laundry_basket,
+            self.test_add_trash_bin,
             self.test_add_pickable,
             self.test_add_map,
             self.test_get_description,
@@ -86,6 +92,10 @@ class DatabaseServiceTester(Node):
         self.pickable_id = 0
         self.shelf_id = 0
         self.table_id = 0
+        self.dishwasher_id = 0
+        self.washer_id = 0
+        self.laundry_basket_id = 0
+        self.trash_bin_id = 0
 
         self.current_test = 0
         self.timer = self.create_timer(0.01, self.run_next_test)
@@ -144,6 +154,18 @@ class DatabaseServiceTester(Node):
 
     async def test_add_pickable(self):
         self.pickable_id = await self.generic_test_add_entity(utils.get_pickable)
+
+    async def test_add_dishwasher(self):
+        self.dishwasher_id = await self.generic_test_add_entity(utils.get_dishwasher)
+
+    async def test_add_washer(self):
+        self.washer_id = await self.generic_test_add_entity(utils.get_washer)
+
+    async def test_add_laundry_basket(self):
+        self.laundry_basket_id = await self.generic_test_add_entity(utils.get_laundry_basket)
+
+    async def test_add_trash_bin(self):
+        self.trash_bin_id = await self.generic_test_add_entity(utils.get_trash_bin)
 
     async def test_add_map(self):
         request = AddMap.Request()
@@ -336,6 +358,10 @@ class DatabaseServiceTester(Node):
             self.pickable_id,
             self.shelf_id,
             self.table_id,
+            self.dishwasher_id,
+            self.washer_id,
+            self.laundry_basket_id,
+            self.trash_bin_id,
         ]
         res = await self.call_service(DelEntities, f"{self.prefix}/del_entities", req)
         self.log_result("DelEntities", res.result)

--- a/code/arlab_knowledge/tests/test_entity.py
+++ b/code/arlab_knowledge/tests/test_entity.py
@@ -82,5 +82,3 @@ def test_convert_laundry_basket():
 def test_convert_trash_bin():
     entity = utils.get_trash_bin()
     convert(entity)
-
-    

--- a/code/arlab_knowledge/tests/test_entity.py
+++ b/code/arlab_knowledge/tests/test_entity.py
@@ -62,3 +62,25 @@ def test_convert_shelf():
 def test_convert_table():
     entity = utils.get_table()
     convert(entity)
+
+
+def test_convert_dishwasher():
+    entity = utils.get_dishwasher()
+    convert(entity)
+
+
+def test_convert_washer():
+    entity = utils.get_washer()
+    convert(entity)
+
+
+def test_convert_laundry_basket():
+    entity = utils.get_laundry_basket()
+    convert(entity)
+
+
+def test_convert_trash_bin():
+    entity = utils.get_trash_bin()
+    convert(entity)
+
+    

--- a/code/arlab_knowledge_interfaces/CMakeLists.txt
+++ b/code/arlab_knowledge_interfaces/CMakeLists.txt
@@ -40,6 +40,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/EntityFurnitureDoor.msg"
   "msg/EntityFurnitureShelf.msg"
   "msg/EntityFurnitureTable.msg"
+  "msg/EntityFurnitureDishwasher.msg"
+  "msg/EntityFurnitureWasher.msg"
+  "msg/EntityFurnitureLaundryBasket.msg"
+  "msg/EntityFurnitureTrashBin.msg"
 
   "msg/EntityType.msg"
   "msg/Result.msg"

--- a/code/arlab_knowledge_interfaces/msg/EntityFurniture.msg
+++ b/code/arlab_knowledge_interfaces/msg/EntityFurniture.msg
@@ -2,9 +2,24 @@
 
 # Attributes for a table (valid if entity_type == table)
 EntityFurnitureTable table
+
 # Attributes for a shelf (valid if entity_type == shelf)
 EntityFurnitureShelf shelf
+
 # Attributes for a door (valid if entity_type == door)
 EntityFurnitureDoor door
+
 # Attributes for a cupboard (valid if entity_type == cupboard)
 EntityFurnitureCupboard cupboard
+
+# Attributes for a dishwasher (valid if entity_type == dishwasher)
+EntityFurnitureDishwasher dishwasher
+
+# Attributes for a washer (valid if entity_type == washer)
+EntityFurnitureWasher washer
+
+#Attributes for a laundry basket (valid if entity_type == laundry_basket)
+EntityFurnitureLaundryBasket laundry_basket
+
+# Attributes for a trash bin (valid if entity_type == trash_bin)
+EntityFurnitureTrashBin trash_bin

--- a/code/arlab_knowledge_interfaces/msg/EntityFurnitureDishwasher.msg
+++ b/code/arlab_knowledge_interfaces/msg/EntityFurnitureDishwasher.msg
@@ -1,0 +1,4 @@
+float64 height
+float64 width
+string open
+# Add further dishwasher specific attributes here

--- a/code/arlab_knowledge_interfaces/msg/EntityFurnitureLaundryBasket.msg
+++ b/code/arlab_knowledge_interfaces/msg/EntityFurnitureLaundryBasket.msg
@@ -1,0 +1,3 @@
+float64 height
+float64 width
+# Add further basket specific attributes here

--- a/code/arlab_knowledge_interfaces/msg/EntityFurnitureTrashBin.msg
+++ b/code/arlab_knowledge_interfaces/msg/EntityFurnitureTrashBin.msg
@@ -1,0 +1,5 @@
+float64 height
+float64 width
+string has_lid
+string open
+# Add further trash bin specific attributes here

--- a/code/arlab_knowledge_interfaces/msg/EntityFurnitureWasher.msg
+++ b/code/arlab_knowledge_interfaces/msg/EntityFurnitureWasher.msg
@@ -1,0 +1,4 @@
+float64 height
+float64 width
+string open
+# Add further washer specific attributes here

--- a/code/arlab_knowledge_interfaces/msg/EntityType.msg
+++ b/code/arlab_knowledge_interfaces/msg/EntityType.msg
@@ -6,6 +6,10 @@ int32 DOOR=4
 int32 TABLE=5
 int32 CUPBOARD=6
 int32 SHELF=7
+int32 DISHWASHER=8
+int32 WASHER=9
+int32 LAUNDRY_BASKET=10
+int32 TRASH_BIN=11
 
 # Enum-like type of an entity. One of the constants defined above.
 int32 id


### PR DESCRIPTION
Adds new task-related entities as requested by specification N-PP-02 and N-L-02 and issue #221. Each is a furniture subclass, inheriting general attributes and adding specifics. 

### New entities: 
| Entity | `EntityType` | Attributes |
  |---|---|---|
  | Dishwasher | `DISHWASHER=8` | `width`, `height`, `open` |
  | Washer (washing machine) | `WASHER=9` | `width`, `height`, `open` |
  | Laundry basket | `LAUNDRY_BASKET=10` | `width`, `height` |
  | Trash bin | `TRASH_BIN=11` | `width`, `height`, `has_lid`, `open` |

### Changes, each for every new entity:
- Added a new .msg file in `arlab_knowledge_interfaces/msg`, extending `EntityFurniture.msg`
- New subclass in `furniture.py` of `arlab_knowledge/db` with mapper in `db/entities/__init__.py`
- sample data creation in `test_utils.py`, `colcon test` integration with `test_entity.py` and add/delete service test in `test_database_node.py`

### How to test
- `colcon build` and `colcon test --package-select arlab_knowledge`
- `ros2 launch arlab_knowledge knowledge_launch.py` and in separate terminal `python3 test_database_node.py` (path: arlab_knowledge/tests/test_database_node.py)

### Notes
- `test_database_node.py` tests only adding / deleting new entities, **not** updating attributes (like the rest of furniture entities). If desired, create commit, PR, comment or address in sprint planning
- Attributes are minimal; If more specifics are needed, create commit, PR, comment or address in sprint planning

Closes #221 