### PR TITLE
[#202] Add auto annotation cmd to movement orchestrator

### DIFF
--- a/code/arlab_computer_vision/launch/object_detection_launch.py
+++ b/code/arlab_computer_vision/launch/object_detection_launch.py
@@ -11,6 +11,8 @@ Maintainers:
 """
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -22,6 +24,12 @@ def generate_launch_description():
             object_detection node.
     """
     ld = LaunchDescription()
+
+    declare_target_frame = DeclareLaunchArgument(
+        "target_frame",
+        default_value="world",
+        description="TF frame the detected entities are transformed into and stored as.",
+    )
 
     # Object detection node with topic remapping
     object_detection_node = Node(
@@ -35,7 +43,7 @@ def generate_launch_description():
         parameters=[
             {"log_level": "INFO"},  # Node parameter for logging verbosity
             {"sync_tolerance": 5.0},
-            {"target_frame": "world"},
+            {"target_frame": LaunchConfiguration("target_frame")},
             {"snapshot_mode": True},
         ],
         arguments=[
@@ -49,7 +57,8 @@ def generate_launch_description():
         ],
     )
 
-    # Add node to the launch description
+    # Add declared arguments and node to the launch description
+    ld.add_action(declare_target_frame)
     ld.add_action(object_detection_node)
 
     return ld

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -42,6 +42,7 @@ class NavErr:
     MAP_SAVE_FAILED = -30
     DB_SERVICE_UNAVAILABLE = -31
     DB_SAVE_FAILED = -32
+    ANNOTATE_SERVER_UNAVAILABLE = -40
 
 
 class NavigationOrchestrator(Node):

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -10,6 +10,7 @@ Maintainers:
     Luca Kahlenberg <luca.kahlenberg@uni-a.de>
 """
 
+import math
 import os
 import signal
 import subprocess
@@ -20,9 +21,11 @@ from typing import Optional, Tuple
 
 import rclpy
 import rclpy.executors
-from arlab_common_interfaces.action import MovementAction
+from arlab_common_interfaces.action import MovementAction, VisionSnapshotAction
+from arlab_common_interfaces.msg import VisionSnapshotResponse
 from arlab_knowledge_interfaces.srv import AddMap
-from nav_msgs.msg import OccupancyGrid
+from nav_msgs.msg import OccupancyGrid, Odometry
+from rclpy.action import ActionClient
 from rclpy.action.server import ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
 from rclpy.node import Node

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -86,6 +86,16 @@ class NavigationOrchestrator(Node):
         self.slam_process: Optional[subprocess.Popen] = None
         self.nav_process: Optional[subprocess.Popen] = None
 
+        # auto-annotation state
+        self.annotate_active = False
+        self._snapshot_in_flight = False
+        self._last_snap_pose: Optional[Tuple[float, float, float]] = None
+        self._last_snap_time = 0.0
+        self._latest_odom: Optional[Odometry] = None
+        self._annotate_timer = None
+        self._odom_sub = None
+        self._snap_lock = threading.Lock()
+
         # subscribe to the map topic to cache the latest map for saving
         self.map_subscription = self.create_subscription(OccupancyGrid, self.map_topic, self.map_callback, 10)
 
@@ -105,6 +115,13 @@ class NavigationOrchestrator(Node):
             cancel_callback=self.cancel_callback,
             callback_group=self.action_group,
         )
+
+        # auto-annotation: snapshot action client + topic publishin if snapshots being taken
+        self.snapshot_action_name = str(self.get_parameter("snapshot_action_name").value)
+        self.snapshot_client = ActionClient(
+            self, VisionSnapshotAction, self.snapshot_action_name, callback_group=self.action_group
+        )
+        self.annotating_pub = self.create_publisher(Bool, "/arlab/movement/annotating", 10)
 
         # legacy topic interface (subscription based control)
         if self.enable_legacy_topics:
@@ -203,6 +220,8 @@ class NavigationOrchestrator(Node):
                 err, msg = self.set_mapping(enable, publish_status)
             elif cmd == "nav":
                 err, msg = self.set_nav(enable, publish_status)
+            elif cmd == "auto_annotate":
+                err, msg = self.set_auto_annotate(enable, publish_status)
             elif cmd == "map_save":
                 err, msg = self.save_map(publish_status)
             elif cmd == "stop_all":
@@ -377,6 +396,60 @@ class NavigationOrchestrator(Node):
         publish_status("Stopping navigation (Nav2)")
         self.nav_process, err, msg = self._stop_process(self.nav_process, "Nav2")
         return err, msg
+
+    # auto-annotation
+    def set_auto_annotate(self, enable: bool, publish_status) -> Tuple[int, str]:
+        """
+        Start or stop periodic CV snapshots that auto-annotate the map.
+
+        When enabled, subscribes to odometry and starts a timer that decides, on
+        each tick:
+        Whether the robot has moved/turned enough since the last
+        snapshot
+        And is moving slowly enough for a stable frame.
+
+        Args:
+            enable (bool): True to start auto-annotation, False to stop it.
+            publish_status (Callable[[str], None]): Callback to publish feedback.
+
+        Returns:
+            Tuple:
+                - int: Error code (NavErr.OK on success)
+                - str: Status or error message
+        """
+        if enable:
+            # start auto-annotation: check for fallpits
+            if self.annotate_active:
+                return NavErr.OK, "auto-annotation already running"
+            if self.slam_process is None or self.slam_process.poll() is not None:
+                self.get_logger().warning("auto_annotate started without SLAM running. map frame may be unavailable.")
+            timeout = float(self.get_parameter("annotate_server_timeout").value)
+            if not self.snapshot_client.wait_for_server(timeout_sec=timeout):
+                return NavErr.ANNOTATE_SERVER_UNAVAILABLE, (f"Snapshot action '{self.snapshot_action_name}' not available")
+            publish_status("Starting auto-annotation (CV snapshots)")
+
+            self._last_snap_pose = None
+            self._last_snap_time = 0.0
+            self._latest_odom = None
+
+            # subscribe to odometry
+            self._odom_sub = self.create_subscription(
+                Odometry,
+                str(self.get_parameter("odom_topic").value),
+                self._odom_callback,
+                10,
+                callback_group=self.service_group,
+            )
+
+            # create a timer to periodically check if a snapshot should be taken / conditions are met
+            period = float(self.get_parameter("annotate_tick_period").value)
+            self._annotate_timer = self.create_timer(period, self._annotate_tick, callback_group=self.action_group)
+            self.annotate_active = True
+            return NavErr.OK, "auto-annotation started"
+
+        publish_status("Stopping auto-annotation")
+        self._teardown_annotation()
+        return NavErr.OK, "auto-annotation stopped"
 
     def stop_all(self):
         """

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -470,6 +470,49 @@ class NavigationOrchestrator(Node):
         """Cache the latest odometry data for speed and turn rate checks"""
         self._latest_odom = msg
 
+    def _annotate_tick(self):
+        """
+        Evaluate the snapshot condition checks and log when a snapshot fires.
+
+        Gates / Checks:
+        - No snapshot in flight -> robot moving slowly linear speed and turn rate
+        - A minimum time interval has elapsed
+        - The robot has moved or turned enough since the last snapshot.
+        """
+        # inactive or not odom -> skip
+        if not self.annotate_active or self._latest_odom is None:
+            return
+        # if snapshot is already running -> skip
+        with self._snap_lock:
+            if self._snapshot_in_flight:
+                return
+
+        # get current odom data
+        x, y, yaw, speed, yaw_rate = self._pose_from_odom(self._latest_odom)
+        now = self.get_clock().now().nanoseconds * 1e-9
+
+        # speed and turn rate checks, if higher than threshold -> skip
+        if speed > float(self.get_parameter("annotate_max_speed").value):
+            return
+        if yaw_rate > float(self.get_parameter("annotate_max_yaw_rate").value):
+            return
+
+        # if last snapshot was too recent -> skip
+        if now - self._last_snap_time < float(self.get_parameter("annotate_min_interval").value):
+            return
+
+        # if last snapshot pose exits, check distance and turned to it, if too small -> skip
+        if self._last_snap_pose is not None:
+            moved = math.hypot(x - self._last_snap_pose[0], y - self._last_snap_pose[1])
+            turned = abs(self._angle_diff(yaw, self._last_snap_pose[2]))
+            if moved < float(self.get_parameter("annotate_min_dist").value) and turned < float(
+                self.get_parameter("annotate_min_yaw").value
+            ):
+                return
+
+        # if all checks pass -> fire snapshot
+        self._fire_snapshot(x, y, yaw, now)
+
     def _pose_from_odom(self, msg: Odometry) -> Tuple[float, float, float, float, float]:
         """Extract planar (x, y, yaw, linear_speed, abs_yaw_rate) from Odometry."""
         p = msg.pose.pose.position

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -123,9 +123,7 @@ class NavigationOrchestrator(Node):
 
         # auto-annotation: snapshot action client + topic publishin if snapshots being taken
         self.snapshot_action_name = str(self.get_parameter("snapshot_action_name").value)
-        self.snapshot_client = ActionClient(
-            self, VisionSnapshotAction, self.snapshot_action_name, callback_group=self.action_group
-        )
+        self.snapshot_client = ActionClient(self, VisionSnapshotAction, self.snapshot_action_name, callback_group=self.action_group)
         self.annotating_pub = self.create_publisher(Bool, "/arlab/movement/annotating", 10)
 
         # legacy topic interface (subscription based control)

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -513,6 +513,67 @@ class NavigationOrchestrator(Node):
         # if all checks pass -> fire snapshot
         self._fire_snapshot(x, y, yaw, now)
 
+    def _fire_snapshot(self, x: float, y: float, yaw: float, now: float):
+        """
+        Send one /vision/snapshot goal and publish to /arlab/movement/annotating.
+
+        Records the snapshot pose/time up front so the gates advance even while
+        the goal is in flight, marks the snapshot as in flight to prevent
+        overlap.
+        Entities are written to the knowledge base by the vision node itself.
+        """
+        goal = VisionSnapshotAction.Goal()
+        goal.command.clear_database = False  # accumulate annotations across the run
+        goal.command.mask_hand = False
+        # extra_models left empty to use general model for annotation
+
+        # set in-flight flag and current snapshot metadata
+        with self._snap_lock:
+            self._snapshot_in_flight = True
+        self._last_snap_pose = (x, y, yaw)
+        self._last_snap_time = now
+
+        # publish to /arlab/movement/annotating to signal operator for running snapshot
+        self.annotating_pub.publish(Bool(data=True))
+        self.get_logger().info(f"auto-annotate: SNAPSHOT IN PROGRESS at ({x:.2f}, {y:.2f}, {yaw:.2f} rad) - hold position.")
+
+        # call action server
+        send_future = self.snapshot_client.send_goal_async(goal)
+        send_future.add_done_callback(self._on_snapshot_goal)
+
+    def _on_snapshot_goal(self, future):
+        """Handle the goal-accepted response and chain to the result future."""
+        try:
+            handle = future.result()
+        # check for exceptions
+        except Exception as e:
+            self._clear_in_flight()
+            self.get_logger().warning(f"Snapshot goal send failed: {e}")
+            return
+        # check for rejection by action server
+        if not handle.accepted:
+            self._clear_in_flight()
+            self.get_logger().warning("Snapshot goal rejected by server.")
+            return
+        handle.get_result_async().add_done_callback(self._on_snapshot_result)
+
+    def _on_snapshot_result(self, future):
+        """Log the snapshot outcome and clear the in-flight flag/operator signal."""
+        self._clear_in_flight()
+        try:
+            response = future.result().result.response
+        except Exception as e:
+            self.get_logger().warning(f"Snapshot result failed: {e}")
+            return
+        if response.result != VisionSnapshotResponse.SUCCESS:
+            self.get_logger().warning(f"Snapshot failed: {response.error_msg}")
+
+    def _clear_in_flight(self):
+        """Mark no snapshot in flight and publish to /arlab/movement/annotating that snapshot finished."""
+        with self._snap_lock:
+            self._snapshot_in_flight = False
+        self.annotating_pub.publish(Bool(data=False))
+
     def _pose_from_odom(self, msg: Odometry) -> Tuple[float, float, float, float, float]:
         """Extract planar (x, y, yaw, linear_speed, abs_yaw_rate) from Odometry."""
         p = msg.pose.pose.position

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -61,6 +61,17 @@ class NavigationOrchestrator(Node):
         # old topic API
         self.declare_parameter("enable_legacy_topics", False)
 
+        # auto-annotation by CV snapshot parameters.
+        self.declare_parameter("snapshot_action_name", "/vision/snapshot")
+        self.declare_parameter("odom_topic", "/odom")
+        self.declare_parameter("annotate_tick_period", 1.0)  # seconds betweeen checks for snapshot conditions
+        self.declare_parameter("annotate_min_dist", 0.75)  # m moved since last snapshot
+        self.declare_parameter("annotate_min_yaw", 0.5)  # rad turned since last snapshot
+        self.declare_parameter("annotate_min_interval", 6.0)  # min interval in seconds between snapshots
+        self.declare_parameter("annotate_max_speed", 0.10)  # only fire when slower than this
+        self.declare_parameter("annotate_max_yaw_rate", 0.20)  # only fire when turning slower than this
+        self.declare_parameter("annotate_server_timeout", 10.0)
+
         self.map_path = str(self.get_parameter("map_path").value)
         self.use_timestamp = bool(self.get_parameter("use_timestamp").value)
         self.save_to_database = bool(self.get_parameter("save_to_database").value)

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -461,6 +461,25 @@ class NavigationOrchestrator(Node):
             self.destroy_subscription(self._odom_sub)
             self._odom_sub = None
 
+    def _odom_callback(self, msg: Odometry):
+        """Cache the latest odometry data for speed and turn rate checks"""
+        self._latest_odom = msg
+
+    def _pose_from_odom(self, msg: Odometry) -> Tuple[float, float, float, float, float]:
+        """Extract planar (x, y, yaw, linear_speed, abs_yaw_rate) from Odometry."""
+        p = msg.pose.pose.position
+        q = msg.pose.pose.orientation
+        yaw = math.atan2(2.0 * (q.w * q.z + q.x * q.y), 1.0 - 2.0 * (q.y * q.y + q.z * q.z))
+        v = msg.twist.twist.linear
+        speed = math.hypot(v.x, v.y)
+        yaw_rate = abs(msg.twist.twist.angular.z)
+        return p.x, p.y, yaw, speed, yaw_rate
+
+    @staticmethod
+    def _angle_diff(a: float, b: float) -> float:
+        """Shortest signed difference between two angles (rad)."""
+        return math.atan2(math.sin(a - b), math.cos(a - b))
+
     def stop_all(self):
         """
         Stop all navigation-related subprocesses.

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -5,8 +5,9 @@ This node implements an action-based orchestrator for managing navigation-relate
 It provides functionality to start/stop localization (AMCL) [currently not used], mapping (SLAM Toolbox),
 and navigation (Nav2), as well as saving the current map to file and optionally to a knowledge database.
 
-Author: Jonas Platzer
-
+Maintainers:
+    Jonas Platzer
+    Luca Kahlenberg <luca.kahlenberg@uni-a.de>
 """
 
 import os

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -451,6 +451,16 @@ class NavigationOrchestrator(Node):
         self._teardown_annotation()
         return NavErr.OK, "auto-annotation stopped"
 
+    def _teardown_annotation(self):
+        """Cancel the annotation timer and remove the odom subscription if active."""
+        self.annotate_active = False
+        if self._annotate_timer is not None:
+            self._annotate_timer.cancel()
+            self._annotate_timer = None
+        if self._odom_sub is not None:
+            self.destroy_subscription(self._odom_sub)
+            self._odom_sub = None
+
     def stop_all(self):
         """
         Stop all navigation-related subprocesses.

--- a/code/arlab_movement/arlab_movement/movement_orchestrator.py
+++ b/code/arlab_movement/arlab_movement/movement_orchestrator.py
@@ -484,9 +484,11 @@ class NavigationOrchestrator(Node):
         """
         Stop all navigation-related subprocesses.
 
-        This shuts down AMCL, SLAM Toolbox, and Nav2 if they are running.
-        Used both for explicit "stop_all" commands and action cancellation.
+        This shuts down AMCL, SLAM Toolbox, and Nav2 if they are running, and
+        also stops auto-annotation if active. Used both for explicit "stop_all"
+        commands and action cancellation.
         """
+        self._teardown_annotation()
         self.amcl_process, _, _ = self._stop_process(self.amcl_process, "AMCL")
         self.slam_process, _, _ = self._stop_process(self.slam_process, "SLAM Toolbox")
         self.nav_process, _, _ = self._stop_process(self.nav_process, "Nav2")

--- a/code/arlab_movement/launch/mapping_drive.launch.py
+++ b/code/arlab_movement/launch/mapping_drive.launch.py
@@ -1,0 +1,139 @@
+"""mapping_drive.launch.py
+
+Bring-up for a mapping drive: starts the movement orchestrator and,
+by default, automatically triggers the mapping (SLAM) and auto-annotation
+behaviours so the operator only has to drive the robot, while system auto
+maps and annotates the environment.
+
+Maintainers:
+    Luca Kahlenberg <luca.kahlenberg@uni-a.de>
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription, OpaqueFunction, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+# Orchestrator action driven by the auto-start block.
+MOVEMENT_ACTION_NAME = "/movement/action"
+MOVEMENT_ACTION_TYPE = "arlab_common_interfaces/action/MovementAction"
+
+
+def _send_movement_goal(cmd: str) -> ExecuteProcess:
+    """Build an ExecuteProcess that sends a single MovementAction goal via the ros2 CLI."""
+    return ExecuteProcess(
+        cmd=[
+            "ros2",
+            "action",
+            "send_goal",
+            MOVEMENT_ACTION_NAME,
+            MOVEMENT_ACTION_TYPE,
+            f"{{cmd: {cmd}, enable: true}}",
+        ],
+        output="screen",
+    )
+
+
+def launch_setup(context, *args, **kwargs):
+    """Resolve arguments and assemble the orchestrator node and auto-start timers."""
+    params_file = LaunchConfiguration("params_file").perform(context)
+    auto_start = LaunchConfiguration("auto_start").perform(context) == "true"
+    mapping_delay = float(LaunchConfiguration("mapping_delay").perform(context))
+    slam_settle_time = float(LaunchConfiguration("slam_settle_time").perform(context))
+    target_frame = LaunchConfiguration("target_frame").perform(context)
+    start_knowledge = LaunchConfiguration("start_knowledge").perform(context) == "true"
+
+    orchestrator = Node(
+        package="arlab_movement",
+        executable="movement_orchestrator",
+        output="screen",
+        parameters=[params_file],
+    )
+
+    # CV node for snapshot ActionServer with target_frame to map
+    object_detection = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("arlab_computer_vision"),
+                "launch",
+                "object_detection_launch.py",
+            )
+        ),
+        launch_arguments={"target_frame": target_frame}.items(),
+    )
+
+    actions = [orchestrator, object_detection]
+
+    # knowledge base launch, so CV can write entities to it
+    if start_knowledge:
+        knowledge = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(
+                    get_package_share_directory("arlab_knowledge"),
+                    "launch",
+                    "knowledge_launch.py",
+                )
+            )
+        )
+        actions.insert(0, knowledge)
+
+    if auto_start:
+        # start SLAM, wait for TF, then start auto annotate.
+        actions.append(TimerAction(period=mapping_delay, actions=[_send_movement_goal("mapping")]))
+        actions.append(
+            TimerAction(
+                period=mapping_delay + slam_settle_time,
+                actions=[_send_movement_goal("auto_annotate")],
+            )
+        )
+
+    return actions
+
+
+def generate_launch_description():
+    """Generate the launch description for the mapping drive bring-up."""
+    default_params_file = os.path.join(
+        get_package_share_directory("arlab_movement"),
+        "params",
+        "arlab_navigation_params.yaml",
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "auto_start",
+                default_value="true",
+                description="Automatically send the mapping and auto_annotate goals after startup. Set false to bring up nodes only.",
+            ),
+            DeclareLaunchArgument(
+                "start_knowledge",
+                default_value="true",
+                description="Start the knowledge base (database + visualization) nodes. Set false if the KB is already running elsewhere.",
+            ),
+            DeclareLaunchArgument(
+                "params_file",
+                default_value=default_params_file,
+                description="Full path to the movement orchestrator parameters file.",
+            ),
+            DeclareLaunchArgument(
+                "target_frame",
+                default_value="map",
+                description="TF frame the CV node stores detected entities in; should match the SLAM map frame.",
+            ),
+            DeclareLaunchArgument(
+                "mapping_delay",
+                default_value="2.0",
+                description="Seconds to wait after startup before sending the mapping (SLAM) goal.",
+            ),
+            DeclareLaunchArgument(
+                "slam_settle_time",
+                default_value="8.0",
+                description="Seconds to wait after the mapping goal (for the map/odom TF to come up) before sending auto_annotate.",
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/code/arlab_movement/package.xml
+++ b/code/arlab_movement/package.xml
@@ -40,6 +40,8 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>teleop_twist_keyboard</exec_depend>
+  <exec_depend>arlab_computer_vision</exec_depend>
+  <exec_depend>arlab_knowledge</exec_depend>
 
   <!--dependencie for rosbot_xl-->
   <depend>laser_filters</depend>

--- a/code/arlab_movement/package.xml
+++ b/code/arlab_movement/package.xml
@@ -5,6 +5,8 @@
   <version>0.0.0</version>
   <description>Package for AR Lab robot movement and navigation.</description>
   <maintainer email="lukas.asam@uni-a.de">Lukas Asam</maintainer>
+  <maintainer email="luca.kahlenberg@uni-a.de>">Luca Kahlenberg</maintainer>
+  
   <license>MIT</license>
 
   <test_depend>python3-pytest</test_depend>

--- a/code/arlab_movement/params/arlab_navigation_params.yaml
+++ b/code/arlab_movement/params/arlab_navigation_params.yaml
@@ -15,6 +15,17 @@ navigation_orchestrator:
     database_service: "/arlab/knowledge/add_map"
     database_timeout: 10.0
 
+    # Auto-annotation (CV snapshot) parameters
+    snapshot_action_name: "/vision/snapshot"
+    odom_topic: "/odom"
+    annotate_tick_period: 1.0       # s, gate evaluation rate
+    annotate_min_dist: 0.75         # m moved since last snapshot
+    annotate_min_yaw: 0.5           # rad turned since last snapshot
+    annotate_min_interval: 6.0      # s floor between snapshots
+    annotate_max_speed: 0.10        # m/s; fire only when slower
+    annotate_max_yaw_rate: 0.20     # rad/s; fire only when slower
+    annotate_server_timeout: 10.0   # s, wait_for_server
+
 map_save_publisher:
   ros__parameters:
     # Auto-save interval in seconds (0 = disabled)


### PR DESCRIPTION
Adds condition-gated CV snapshots during a mapping drive to auto-annotate the map.

The advised workflow is: Teleop, Drive into a new room, hold the robot still for ~5s, auto snapshot fires, continue. 
The expected outcome is: ~one snapshot per room, relevant entities in room are now in the knowledge base.

## What changed

### orchestrator
New movement orchestrator action goal `cmd: auto_annotate` (`enable: true|false`). 
While driving, the orchestrator periodically fires a `/vision/snapshot` goal when all of these conditions are met:

- speed < a max speed
- yaw rate < a max yaw rate
- minimum interval since last snapshot
- the robot moved or turned a minimum distance at least
- no snapshot is in flight rn.

During a snapshot it publishes `Bool` on `/arlab/movement/annotating`, so later signaling to an operator via GUI is possible.
The segmented entities are added to the KB, accumulating over the drive. 

### launch file
Also adds `mapping_drive.launch.py`, bring up for: KB + orchestrator + CV, auto-fires `mapping` then `auto_annotate` 
`auto_start`, `start_knowledge` and `target_frame` are launch arguments.

## How to test
1. build and source.
2. prereq: simulation, camera and postgres container running
3. `ros2 launch arlab_movement mapping_drive.launch.py` 
4. Teleop-drive slowly (in a simulation) → snapshots fire when gated; `/arlab/movement/annotating` toggles; entities land in the KB.

## Notes
- The launch file does not include a simulation. For now it was tested using turtlebot. 
- Right now, the CV models used are not set using ´extra_models´. This leads to default model set in ´object_detection´ node. **We need to decide with CV team which models to use.** 

This PR closes issue #202 